### PR TITLE
[jq-likes] Remove the version option

### DIFF
--- a/src/jq-likes/devcontainer-feature.json
+++ b/src/jq-likes/devcontainer-feature.json
@@ -5,14 +5,6 @@
 	"description": "Installs jq and jq like command line tools (yq, gojq).",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/jq-likes",
 	"options": {
-		"version": {
-			"type": "string",
-			"proposals": [
-				"latest"
-			],
-			"default": "latest",
-			"description": "Currently unused."
-		},
 		"jqVersion": {
 			"type": "string",
 			"enum": [

--- a/src/jq-likes/devcontainer-feature.json
+++ b/src/jq-likes/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "jq and jq like tools",
 	"id": "jq-likes",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Installs jq and jq like command line tools (yq, gojq).",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/jq-likes",
 	"options": {


### PR DESCRIPTION
The version option does not seem needed for this feature (e.g. `ghcr.io/devcontainers/features/common-utils`)