### PR TITLE
[go-task] Fix permission of the zsh completion file

### DIFF
--- a/src/go-task/devcontainer-feature.json
+++ b/src/go-task/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Task",
 	"id": "go-task",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Installs Task, a task runner / simpler Make alternative.",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/go-task",
 	"options": {

--- a/src/go-task/install.sh
+++ b/src/go-task/install.sh
@@ -117,6 +117,7 @@ setup_completions() {
     if [ "$for_zsh" = "true" ] && [ -f "$zsh_comp_file" ] && [ -d /usr/local/share/zsh/site-functions/ ] ; then
         echo "Installing zsh completion..."
         mv "$zsh_comp_file" /usr/local/share/zsh/site-functions/_task
+        chown -R "${USERNAME}:${USERNAME}" /usr/local/share/zsh/site-functions/_task
     fi
 
     # fish


### PR DESCRIPTION
If the root user has the file, zsh will not read this file by default.