### PR TITLE
[go-task][jq-likes] Use the _REMOTE_USER env var if available and bump versions to 1.0.0

### DIFF
--- a/src/go-task/devcontainer-feature.json
+++ b/src/go-task/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Task",
 	"id": "go-task",
-	"version": "0.2.3",
+	"version": "1.0.0",
 	"description": "Installs Task, a task runner / simpler Make alternative.",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/go-task",
 	"options": {

--- a/src/go-task/install.sh
+++ b/src/go-task/install.sh
@@ -2,7 +2,7 @@
 
 TASK_VERSION=${VERSION:-"latest"}
 
-USERNAME=${USERNAME:-"automatic"}
+USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
 
 set -e
 

--- a/src/jq-likes/devcontainer-feature.json
+++ b/src/jq-likes/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "jq, yq, gojq",
 	"id": "jq-likes",
-	"version": "0.2.0",
+	"version": "1.0.0",
 	"description": "Installs jq and jq like command line tools (yq, gojq).",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/jq-likes",
 	"options": {

--- a/src/jq-likes/install.sh
+++ b/src/jq-likes/install.sh
@@ -4,7 +4,7 @@ JQ_VERSION=${JQVERSION:-"os-provided"}
 YQ_VERSION=${YQVERSION:-"none"}
 GOJQ_VERSION=${GOJQVERSION:-"none"}
 
-USERNAME=${USERNAME:-"automatic"}
+USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
 
 set -e
 

--- a/test/go-task/install-with-fish-pwsh-non-root.sh
+++ b/test/go-task/install-with-fish-pwsh-non-root.sh
@@ -2,25 +2,14 @@
 
 set -e
 
-NON_ROOT_USER=""
-POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
-for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-  if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-    NON_ROOT_USER="${CURRENT_USER}"
-    break
-  fi
-done
-if [ "${NON_ROOT_USER}" = "" ]; then
-  NON_ROOT_USER=root
-fi
-
 # shellcheck source=/dev/null
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "fish completion" cat "/home/${NON_ROOT_USER}/.config/fish/completions/task.fish"
-check "pwsh completion" cat "/home/${NON_ROOT_USER}/.local/share/powershell/Scripts/task.ps1"
-check "pwsh profile" cat "/home/${NON_ROOT_USER}/.config/powershell/Microsoft.PowerShell_profile.ps1" | grep "task.ps1"
+check "ensure i am user vscode"  bash -c "whoami | grep 'vscode'"
+check "fish completion" cat ~/.config/fish/completions/task.fish
+check "pwsh completion" cat ~/.local/share/powershell/Scripts/task.ps1
+check "pwsh profile" cat ~/.config/powershell/Microsoft.PowerShell_profile.ps1 | grep "task.ps1"
 
 # Report result
 reportResults

--- a/test/jq-likes/install-with-zsh-fish-pwsh-non-root.sh
+++ b/test/jq-likes/install-with-zsh-fish-pwsh-non-root.sh
@@ -2,27 +2,16 @@
 
 set -e
 
-NON_ROOT_USER=""
-POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
-for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-  if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-    NON_ROOT_USER="${CURRENT_USER}"
-    break
-  fi
-done
-if [ "${NON_ROOT_USER}" = "" ]; then
-  NON_ROOT_USER=root
-fi
-
 # shellcheck source=/dev/null
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "yq zsh completion" cat "/usr/local/share/zsh/site-functions/_yq"
-check "yq fish completion" cat "/home/${NON_ROOT_USER}/.config/fish/completions/yq.fish"
-check "yq pwsh completion" cat "/home/${NON_ROOT_USER}/.local/share/powershell/Scripts/yq.ps1"
-check "yq pwsh profile" cat "/home/${NON_ROOT_USER}/.config/powershell/Microsoft.PowerShell_profile.ps1" | grep "yq.ps1"
-check "gojq zsh completion" cat "/usr/local/share/zsh/site-functions/_gojq"
+check "ensure i am user vscode"  bash -c "whoami | grep 'vscode'"
+check "yq zsh completion" cat /usr/local/share/zsh/site-functions/_yq
+check "yq fish completion" cat ~/.config/fish/completions/yq.fish
+check "yq pwsh completion" cat ~/.local/share/powershell/Scripts/yq.ps1
+check "yq pwsh profile" cat ~/.config/powershell/Microsoft.PowerShell_profile.ps1 | grep "yq.ps1"
+check "gojq zsh completion" cat /usr/local/share/zsh/site-functions/_gojq
 
 # Report result
 reportResults


### PR DESCRIPTION
Same as devcontainers/features#264

The recent update of the devcontainer CLI seems to have improved testing for non-root users (devcontainers/cli#286), so I am also update some test cases for non-root users.

The `go-task` and `jq-likes` Features have been downloaded a lot and I feel it is stable enough for my own use, so I am bumping the versions up to 1.0.0.