### PR TITLE
[duckdb-cli] add a new options to install extensions

### DIFF
--- a/src/duckdb-cli/NOTES.md
+++ b/src/duckdb-cli/NOTES.md
@@ -4,7 +4,24 @@
 
 `linux/amd64` and `linux/arm64` platforms `debian` and `ubuntu`.
 
+## How to specify extensions?
+
+Specify extension names separated by commas in the `extensions` option.
+
+The following example installs `httpfs` and `sqlite_scanner`.
+
+```json
+"features": {
+    "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1": {
+        "extensions": "httpfs,sqlite_scanner"
+    }
+}
+```
+
+Currently, only supports signed extensions.
+
 ## References
 
 - DuckDB: <https://duckdb.org>
-- DuckDB CLI API <https://duckdb.org/docs/api/cli>
+- DuckDB CLI API: <https://duckdb.org/docs/api/cli>
+- DuckDB Extensions: <https://duckdb.org/docs/extensions/overview>

--- a/src/duckdb-cli/devcontainer-feature.json
+++ b/src/duckdb-cli/devcontainer-feature.json
@@ -23,5 +23,7 @@
 			]
 		}
 	},
-	"installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
+	"installsAfter": [
+		"ghcr.io/devcontainers/features/common-utils"
+	]
 }

--- a/src/duckdb-cli/devcontainer-feature.json
+++ b/src/duckdb-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "DuckDB CLI",
 	"id": "duckdb-cli",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "DuckDB is an in-process SQL OLAP database management system.",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/duckdb-cli",
 	"options": {

--- a/src/duckdb-cli/devcontainer-feature.json
+++ b/src/duckdb-cli/devcontainer-feature.json
@@ -12,9 +12,16 @@
 			],
 			"default": "latest",
 			"description": "Select version of DuckDB CLI."
+		},
+		"extensions": {
+			"type": "string",
+			"default": "",
+			"description": "Comma separated list of DuckDB extensions to install.",
+			"proposals": [
+				"",
+				"httpfs,sqlite_scanner"
+			]
 		}
 	},
-	"installsAfter": [
-		"ghcr.io/devcontainers/features/common-utils"
-	]
+	"installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
 }

--- a/src/duckdb-cli/install.sh
+++ b/src/duckdb-cli/install.sh
@@ -97,14 +97,14 @@ find_version_from_git_tags() {
 
 install_extensions() {
     local username=$1
-    local extensions=("${2//,/ }")
-    if [ "${#extensions[@]}" -gt 0 ]; then
-        for extension in "${extensions[@]}"; do
-            echo "Installing DuckDB '${extension}' extension..."
-            su "${username}" -c "duckdb -c \"install '${extension}'\""
-            echo "Done!"
-        done
-    fi
+    local extensions
+    IFS=',' read -r -a extensions <<< "$2"
+
+    for extension in "${extensions[@]}"; do
+        echo "Installing DuckDB '${extension}' extension..."
+        su "${username}" -c "duckdb -c \"install '${extension}'\""
+        echo "Done!"
+    done
 }
 
 export DEBIAN_FRONTEND=noninteractive

--- a/src/duckdb-cli/install.sh
+++ b/src/duckdb-cli/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 CLI_VERSION=${VERSION:-"latest"}
+DB_EXTENSIONS=("${EXTENSIONS//,/ }")
 
 set -e
 
@@ -93,6 +94,12 @@ mv duckdb /usr/bin/duckdb
 
 popd
 rm -rf /tmp/duckdb-cli
+
+for extension in "${DB_EXTENSIONS[@]}"; do
+    echo "Installing DuckDB '${extension}' extension..."
+    su "${USERNAME}" -c "duckdb -c \"install '${extension}'\""
+    echo "Done!"
+done
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/src/duckdb-cli/install.sh
+++ b/src/duckdb-cli/install.sh
@@ -103,7 +103,7 @@ install_extensions() {
     for extension in "${extensions[@]}"; do
         echo "Installing DuckDB '${extension}' extension..."
         su "${username}" -c "duckdb -c \"install '${extension}'\""
-        echo "Done!"
+        echo "Install '${extension}' extension successfully!"
     done
 }
 

--- a/test/duckdb-cli/extensions.sh
+++ b/test/duckdb-cli/extensions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "httpfs" bash -c "duckdb -c 'load httpfs'"
+check "sqlite_scanner" bash -c "duckdb -c 'load sqlite_scanner'"
+
+# Report result
+reportResults

--- a/test/duckdb-cli/scenarios.json
+++ b/test/duckdb-cli/scenarios.json
@@ -6,5 +6,13 @@
 				"version": "0.5"
 			}
 		}
+	},
+	"extensions": {
+		"image": "mcr.microsoft.com/devcontainers/base:debian",
+		"features": {
+			"duckdb-cli": {
+				"extensions": "httpfs,sqlite_scanner"
+			}
+		}
 	}
 }


### PR DESCRIPTION
Close #65

Only supports the default repository and signed extensions now.