### PR TITLE
[go-task] install the vscode extension for task

### DIFF
--- a/src/go-task/devcontainer-feature.json
+++ b/src/go-task/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Task",
 	"id": "go-task",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Installs Task, a task runner / simpler Make alternative.",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/go-task",
 	"options": {

--- a/src/go-task/devcontainer-feature.json
+++ b/src/go-task/devcontainer-feature.json
@@ -19,5 +19,12 @@
 		"ghcr.io/devcontainers/features/common-utils",
 		"ghcr.io/devcontainers/features/powershell",
 		"ghcr.io/meaningful-ooo/devcontainer-features/fish"
-	]
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"task.vscode-task"
+			]
+		}
+	}
 }


### PR DESCRIPTION
Update the configuration for VS Code to install the VS Code extensions announced in the latest release of Task (https://github.com/go-task/task/releases/tag/v3.23.0).