### PR TITLE
[duckdb-cli] Workaround for duckdb using aarch64 to mean arm64

### DIFF
--- a/src/duckdb-cli/devcontainer-feature.json
+++ b/src/duckdb-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "DuckDB CLI",
 	"id": "duckdb-cli",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "DuckDB is an in-process SQL OLAP database management system.",
 	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/duckdb-cli",
 	"options": {

--- a/src/duckdb-cli/install.sh
+++ b/src/duckdb-cli/install.sh
@@ -118,7 +118,8 @@ echo "Downloading DuckDB CLI..."
 
 mkdir /tmp/duckdb-cli
 pushd /tmp/duckdb-cli
-curl -sL "https://github.com/duckdb/duckdb/releases/download/v${CLI_VERSION}/duckdb_cli-linux-$(dpkg --print-architecture).zip" -o duckdb_cli.zip
+echo "CURLING" curl -sL "https://github.com/duckdb/duckdb/releases/download/v${CLI_VERSION}/duckdb_cli-linux-$(dpkg --print-architecture).zip" -o duckdb_cli.zip
+curl -L "https://github.com/duckdb/duckdb/releases/download/v${CLI_VERSION}/duckdb_cli-linux-$(dpkg --print-architecture).zip" -o duckdb_cli.zip
 
 unzip duckdb_cli.zip
 mv duckdb /usr/bin/duckdb

--- a/src/duckdb-cli/install.sh
+++ b/src/duckdb-cli/install.sh
@@ -118,8 +118,9 @@ echo "Downloading DuckDB CLI..."
 
 mkdir /tmp/duckdb-cli
 pushd /tmp/duckdb-cli
-echo "CURLING" curl -sL "https://github.com/duckdb/duckdb/releases/download/v${CLI_VERSION}/duckdb_cli-linux-$(dpkg --print-architecture).zip" -o duckdb_cli.zip
-curl -L "https://github.com/duckdb/duckdb/releases/download/v${CLI_VERSION}/duckdb_cli-linux-$(dpkg --print-architecture).zip" -o duckdb_cli.zip
+duckdb_arch=$(dpkg --print-architecture)
+if [ "${duckdb_arch}" = "arm64" ] ; then duckdb_arch="aarch64" ; fi
+curl -fL --no-progress-meter "https://github.com/duckdb/duckdb/releases/download/v${CLI_VERSION}/duckdb_cli-linux-${duckdb_arch}.zip" -o duckdb_cli.zip
 
 unzip duckdb_cli.zip
 mv duckdb /usr/bin/duckdb


### PR DESCRIPTION
This feature does not currently work correctly on `arm64` architectures (such as Mac M1) because duckdb calls that `aarch64`. Work around that.

Also change curl parameters to fail on 404, instead of creating an invalid zip file

