### PR TITLE
test: update broken tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,8 +42,8 @@ jobs:
         features: ${{ fromJSON(needs.detect-changes.outputs.features) }}
         baseImage:
           - debian:stable-slim
-          - ubuntu:focal
           - ubuntu:jammy
+          - ubuntu:noble
           - mcr.microsoft.com/devcontainers/base:ubuntu
           - mcr.microsoft.com/devcontainers/base:debian
     steps:
@@ -89,8 +89,8 @@ jobs:
           - nushell
         baseImage:
           - debian:stable-slim
-          - ubuntu:focal
           - ubuntu:jammy
+          - ubuntu:noble
           - mcr.microsoft.com/devcontainers/base:ubuntu
           - mcr.microsoft.com/devcontainers/base:debian
     steps:

--- a/test/duckdb-cli/community-extensions.sh
+++ b/test/duckdb-cli/community-extensions.sh
@@ -6,7 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "duckpgq" bash -c "duckdb -c 'load duckpgq'"
+check "nanoarrow" bash -c "duckdb -c 'load nanoarrow'"
 check "quack" bash -c "duckdb -c 'load quack'"
 
 # Report result

--- a/test/duckdb-cli/scenarios.json
+++ b/test/duckdb-cli/scenarios.json
@@ -19,7 +19,7 @@
 		"image": "mcr.microsoft.com/devcontainers/base:debian",
 		"features": {
 			"duckdb-cli": {
-				"communityExtensions": "duckpgq, quack"
+				"communityExtensions": "nanoarrow, quack"
 			}
 		}
 	}


### PR DESCRIPTION
- Remove tests on Ubuntu 20.04 (Nushell no longer support this).
- Use the `nanoarrow` extension for DuckDB Feature (It seems supported by the DuckDB team).